### PR TITLE
TextAreaコンポーネント作成

### DIFF
--- a/src/components/TextArea/TextArea.stories.tsx
+++ b/src/components/TextArea/TextArea.stories.tsx
@@ -1,0 +1,16 @@
+import TextArea from '.';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta = {
+    title: 'components/TextArea',
+    component: TextArea,
+} satisfies Meta<typeof TextArea>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    args: {
+        placeholder: '本文',
+    },
+};

--- a/src/components/TextArea/index.tsx
+++ b/src/components/TextArea/index.tsx
@@ -1,0 +1,26 @@
+import React, { useState } from 'react';
+
+type Props = {
+    placeholder?: string;
+};
+
+const TextArea: React.FC<Props> = ({ placeholder }) => {
+    const [value, setValue] = useState('');
+
+    const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+        setValue(e.target.value);
+    };
+
+    return (
+        <div>
+            <textarea
+                className="w-full h-[382px] border-2 border-light-gray rounded-lg p-2 resize-none"
+                placeholder={placeholder}
+                value={value}
+                onChange={handleChange}
+            />
+        </div>
+    );
+};
+
+export default TextArea;

--- a/src/components/TextArea/index.tsx
+++ b/src/components/TextArea/index.tsx
@@ -1,7 +1,8 @@
+"use client";
 import React, { useState } from 'react';
 
 type Props = {
-    placeholder?: string;
+    placeholder: string;
 };
 
 const TextArea: React.FC<Props> = ({ placeholder }) => {


### PR DESCRIPTION
## 対応する issue

-   closes #12 

## 対応内容

TextAreaコンポーネント作成
・文字の入力、削除
・placeholderは本文
・height: 382pxで設定
・placeholderを抽象的に定義する(Props受け取るが、オプショナルにはしない)
・TextAreaコンポーネントをcomponents以下に作成

## 動作確認

![image](https://github.com/user-attachments/assets/9cbf342a-1833-405e-9612-46be6cdcdf1d)
![image](https://github.com/user-attachments/assets/2756db91-408f-4f97-b640-e8e833da5e1c)

