### PR TITLE
LinkTextコンポーネント作成

### DIFF
--- a/src/components/LinkText/LinkText.stories.tsx
+++ b/src/components/LinkText/LinkText.stories.tsx
@@ -1,0 +1,35 @@
+import LinkText from '.';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta = {
+    title: 'components/LinkText',
+    component: LinkText,
+    argTypes: {
+        children: { control: 'text' },
+        href: { control: 'text' },
+    },
+    parameters: {
+        backgrounds: {
+            default: 'lightBlue',
+            values: [
+                { name: 'lightBlue', value: '#1E90FF' },
+            ],
+        },
+    },
+} satisfies Meta<typeof LinkText>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    args: {
+        children: 'メモ一覧',
+        href: '/',
+    },
+    render: (args) => (
+        <div className="flex space-x-10">
+            <LinkText {...args} />
+            <LinkText href="/">メモ作成</LinkText>
+        </div>
+    ),
+};

--- a/src/components/LinkText/index.tsx
+++ b/src/components/LinkText/index.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import React from 'react';
 
 type Props = {
@@ -7,7 +8,7 @@ type Props = {
 
 const LinkText: React.FC<Props> = ({ children, href }) => {
     return (
-        <a
+        <Link
             href={href}
             className="font-noto-sans text-[24px] text-white !text-white hover:opacity-70 transition-opacity duration-300"
             style={{ color: 'white' }}
@@ -16,7 +17,7 @@ const LinkText: React.FC<Props> = ({ children, href }) => {
             }}
         >
             {children}
-        </a>
+        </Link>
     );
 };
 

--- a/src/components/LinkText/index.tsx
+++ b/src/components/LinkText/index.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+type Props = {
+    children: React.ReactNode;
+    href: string;
+};
+
+const LinkText: React.FC<Props> = ({ children, href }) => {
+    return (
+        <a
+            href={href}
+            className="font-noto-sans text-[24px] text-white !text-white hover:opacity-70 transition-opacity duration-300"
+            style={{ color: 'white' }}
+            onClick={(e) => {
+                e.preventDefault();
+            }}
+        >
+            {children}
+        </a>
+    );
+};
+
+export default LinkText;


### PR DESCRIPTION
## 対応する issue

-   closes #9 

## 対応内容

・fontFamily-NotoSans
・fontSizeを24pxで設定
・文字をwhiteに設定
・hoverActionはtransition: 0.3, opacity: 0.7
・clickActionは一旦 "/" で仮置き

## 動作確認
![image](https://github.com/user-attachments/assets/4540fb2c-9d87-49c4-b8ff-f7aa7a2abf4a)

hover
![image](https://github.com/user-attachments/assets/5aab1526-2f2c-46e0-9ab8-54521d242eff)

