### PR TITLE
ユーザー作成画面の作成

### DIFF
--- a/src/app/userCreate/page.tsx
+++ b/src/app/userCreate/page.tsx
@@ -1,3 +1,5 @@
-export default function UserCreate() {
-	return <h1>タグ作成・編集ページ</h1>;
+import { UserCreate } from '@/features/UserCreate';
+
+export default function UserCreatePage() {
+	return <UserCreate />;
 }

--- a/src/features/UserCreate/UserCreate.stories.tsx
+++ b/src/features/UserCreate/UserCreate.stories.tsx
@@ -1,0 +1,14 @@
+import { UserCreate } from '.';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta = {
+	title: 'features/UserCreate',
+	component: UserCreate,
+} satisfies Meta<typeof UserCreate>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+	args: {},
+};

--- a/src/features/UserCreate/index.tsx
+++ b/src/features/UserCreate/index.tsx
@@ -1,0 +1,24 @@
+import ColorButton from '@/components/ColorButton';
+import Input from '@/components/Input';
+import Title from '@/components/Title';
+
+export function UserCreate() {
+	return (
+		<div className='flex h-screen flex-col justify-center gap-8 px-48'>
+			<Title
+				fontSize='l'
+				isBold
+			>
+				ユーザーを作成
+			</Title>
+			<Input placeholder='ユーザー名' />
+			<Input placeholder='パスワード' />
+			<div className='flex justify-end'>
+				<ColorButton
+					color='green'
+					label='登録'
+				></ColorButton>
+			</div>
+		</div>
+	);
+}


### PR DESCRIPTION
## 対応する issue

-   closes #38

## 対応内容

- ユーザー登録画面の追加（ほぼログイン画面と同じ）
- パスワードが平文表示なのが気になる。

## 動作確認

![image](https://github.com/user-attachments/assets/b59b6b67-e7a2-4db9-a0bb-b6fed1721380)

