### PR TITLE
Feature/#23 memo list itemコンポーネント作成

### DIFF
--- a/src/components/Tag/Tag.stories.tsx
+++ b/src/components/Tag/Tag.stories.tsx
@@ -1,0 +1,17 @@
+import Tag from '.';
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta = {
+	title: 'components/Tag',
+	component: Tag,
+} satisfies Meta<typeof Tag>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+	args: {
+		children: 'サンプルタグ',
+	},
+};

--- a/src/components/Tag/index.tsx
+++ b/src/components/Tag/index.tsx
@@ -1,0 +1,13 @@
+type Props = {
+	children: string | number;
+};
+
+const Tag = ({ children }: Props) => {
+	return (
+		<span className='font-noto rounded-full bg-gray-200 px-2 py-1 text-black'>
+			{children}
+		</span>
+	);
+};
+
+export default Tag;

--- a/src/components/Tag/index.tsx
+++ b/src/components/Tag/index.tsx
@@ -4,7 +4,7 @@ type Props = {
 
 const Tag = ({ children }: Props) => {
 	return (
-		<span className='font-noto rounded-full bg-gray-200 px-2 py-1 text-black'>
+		<span className='font-noto py-0.3 rounded-full bg-gray-200 px-2.5 text-sm text-black'>
 			{children}
 		</span>
 	);

--- a/src/features/MemoList/MemoListItem/MemoListItem.stories.tsx
+++ b/src/features/MemoList/MemoListItem/MemoListItem.stories.tsx
@@ -1,0 +1,43 @@
+import MemoListItem from '.';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta = {
+	title: 'features/MemoList/MemoListItem',
+	component: MemoListItem,
+} satisfies Meta<typeof MemoListItem>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+type Tag = {
+	id: number;
+	name: string;
+	priority: number;
+};
+
+const tags: Tag[] = [
+	{
+		id: 1,
+		name: 'タグ名1',
+		priority: 1,
+	},
+	{
+		id: 2,
+		name: 'タグ名2',
+		priority: 3,
+	},
+	{
+		id: 3,
+		name: 'タグ名3',
+		priority: 2,
+	},
+];
+
+export const Default: Story = {
+	args: {
+		userName: 'ユーザ名',
+		createdDate: '2024/1/1((日付の型定義は親画面で担保)',
+		memoTitle: 'メモタイトル',
+		tags: tags,
+	},
+};

--- a/src/features/MemoList/MemoListItem/index.tsx
+++ b/src/features/MemoList/MemoListItem/index.tsx
@@ -1,0 +1,36 @@
+import Tag from '@/components/Tag';
+import Text from '@/components/Text';
+import Title from '@/components/Title';
+
+type Tag = {
+	id: number;
+	name: string;
+	priority: number;
+};
+
+type Props = {
+	userName: string;
+	createdDate: string;
+	memoTitle: string;
+	tags?: Tag[];
+};
+
+const MemoListItem = ({ userName, createdDate, memoTitle, tags = [] }: Props) => {
+	const sortedTags = [...tags].sort((a, b) => {
+		return a.priority === b.priority ? b.id - a.id : b.priority - a.priority;
+	});
+	return (
+		<div className='flex flex-col justify-center gap-2 rounded-lg bg-gray-100 p-3'>
+			<Text fontSize='l'>{userName}</Text>
+			<Text fontSize='s'>{createdDate}</Text>
+			<Title isBold>{memoTitle}</Title>
+			<div className='flex space-x-2'>
+				{sortedTags.map((tag) => {
+					return <Tag key={tag.id}>{tag.name}</Tag>;
+				})}
+			</div>
+		</div>
+	);
+};
+
+export default MemoListItem;


### PR DESCRIPTION
## 対応する issue

-   closes #23 

## 対応内容

- MemoListItemを作成
- 日付は string で受け取るようにしてフォーマットが親画面で担保
- タグは priority の降順、id の降順でソートして左から並べた

## 動作確認

![image](https://github.com/user-attachments/assets/a3110b24-6a82-4de5-a32b-9485933fe3d9)

