### PR TITLE
Feature/#39 メモ詳細画面の実装(モック)

### DIFF
--- a/src/components/DateLabel/DateLabel.stories.tsx
+++ b/src/components/DateLabel/DateLabel.stories.tsx
@@ -1,0 +1,21 @@
+import DateLabel from '.';
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta = {
+	title: 'components/DateLabel',
+	component: DateLabel,
+} satisfies Meta<typeof DateLabel>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+	args: {
+		utcDateTimeString: '2024-09-15T10:12:14.000Z',
+		label: '登録日時',
+		containSecond: false,
+		fontSize: 'm',
+		color: 'black',
+	},
+};

--- a/src/components/DateLabel/index.tsx
+++ b/src/components/DateLabel/index.tsx
@@ -1,0 +1,51 @@
+import Text from '../Text';
+import { useDateTime } from '../../hooks/useDateTime';
+
+const FONT_SIZES = {
+	l: 'text-xl',
+	m: 'text-base',
+	s: 'text-xs',
+} as const;
+
+type Props = {
+	utcDateTimeString: string;
+	label?: string;
+	containSecond?: boolean;
+	fontSize?: keyof typeof FONT_SIZES;
+	color?: string;
+};
+
+const DateLabel = ({
+	utcDateTimeString,
+	label,
+	containSecond,
+	fontSize = 'm',
+	color = 'black',
+}: Props) => {
+
+	const utcDate = new Date(utcDateTimeString);
+	if (isNaN(utcDate.getTime())) {
+		return;
+	}
+
+	return (
+		<div>
+			{label && (
+				<Text
+					fontSize={fontSize}
+					color={color}
+				>
+					{label + '：'}
+				</Text>
+			)}
+			<Text
+				fontSize={fontSize}
+				color={color}
+			>
+				{useDateTime(utcDateTimeString, containSecond)!}
+			</Text>
+		</div>
+	);
+};
+
+export default DateLabel;

--- a/src/components/IconButton/index.tsx
+++ b/src/components/IconButton/index.tsx
@@ -12,39 +12,34 @@ const ICON_BUTTON_SIZES = {
 	s: 'h-5 w-5',
 } as const;
 
-const ICON_JUSTIFIED = {
-	top: 'items-start',
-	center: 'items-center',
+const ICON_TYPE = {
+	edit: 'i-ic-edit',
+	delete: 'i-ic-delete',
 } as const;
 
 type Props = {
 	label?: string;
 	size?: keyof typeof ICON_SIZES;
-	iconJustified?: keyof typeof ICON_JUSTIFIED;
-	iconType: 'edit' | 'delete';
+	iconType: keyof typeof ICON_TYPE;
 	onClickHandler: (...args: unknown[]) => unknown;
 };
 
-const IconButton = ({
-	label = undefined,
-	size = 's',
-	iconJustified = 'center',
-	iconType,
-	onClickHandler,
-}: Props) => {
+const IconButton = ({ label, size = 's', iconType, onClickHandler }: Props) => {
+	const buttonSizeClass = label ? 'w-20 h-15' : `${ICON_BUTTON_SIZES[size]} h-15`;
+	const iconClass = `${ICON_TYPE[iconType]} ${ICON_SIZES[size]} ${label ? 'm-0.5 p-2' : ICON_BUTTON_SIZES[size]}`;
+
 	return (
-		<div className={`h-15 ${label === undefined ? ICON_BUTTON_SIZES[size] : 'w-20'}`}>
+		<div className={buttonSizeClass}>
 			<button
 				onClick={onClickHandler}
-				className={`flex ${ICON_JUSTIFIED[iconJustified]}`}
+				className={`flex items-center`}
 			>
-				<span
-					className={`i-ic-${iconType} ${label === undefined ? ICON_BUTTON_SIZES[size] : 'm-0.5 p-2'} ${ICON_SIZES[size]}`}
-				></span>
+				<span className={iconClass}></span>
 				{label && <Text fontSize='m'>{label}</Text>}
 			</button>
 		</div>
 	);
 };
+
 
 export default IconButton;

--- a/src/components/IconButton/index.tsx
+++ b/src/components/IconButton/index.tsx
@@ -2,21 +2,48 @@
 
 import Text from '../Text';
 
+const ICON_SIZES = {
+	m: 'h-8 w-8',
+	s: 'h-4 w-4',
+} as const;
+
+const ICON_BUTTON_SIZES = {
+	m: 'h-10 w-10',
+	s: 'h-5 w-5',
+} as const;
+
+const ICON_JUSTIFIED = {
+	top: 'items-start',
+	center: 'items-center',
+} as const;
+
 type Props = {
 	label?: string;
+	size?: keyof typeof ICON_SIZES;
+	iconJustified?: keyof typeof ICON_JUSTIFIED;
 	iconType: 'edit' | 'delete';
-	onclickHandler: (...args: unknown[]) => unknown;
+	onClickHandler: (...args: unknown[]) => unknown;
 };
 
-const IconButton = ({ label, iconType, onclickHandler }: Props) => {
+const IconButton = ({
+	label = undefined,
+	size = 's',
+	iconJustified = 'center',
+	iconType,
+	onClickHandler,
+}: Props) => {
 	return (
-		<button
-			onClick={onclickHandler}
-			className='flex h-full items-center'
-		>
-			<span className={`i-ic-${iconType} m-0.5 h-8 w-8 p-2`}></span>
-			{label && <Text>{label}</Text>}
-		</button>
+		<div className={`h-15 ${label === undefined ? ICON_BUTTON_SIZES[size] : 'w-20'}`}>
+			<button
+				onClick={onClickHandler}
+				className={`flex ${ICON_JUSTIFIED[iconJustified]}`}
+			>
+				<span
+					className={`i-ic-${iconType} ${label === undefined ? ICON_BUTTON_SIZES[size] : 'm-0.5 p-2'} ${ICON_SIZES[size]}`}
+				></span>
+				{label && <Text fontSize='m'>{label}</Text>}
+			</button>
+		</div>
 	);
 };
 

--- a/src/features/MemoDetail/MemoDetail.stories.tsx
+++ b/src/features/MemoDetail/MemoDetail.stories.tsx
@@ -1,0 +1,135 @@
+import { MemoDetail } from '.';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta = {
+	title: 'features/MemoDetail',
+	component: MemoDetail,
+} satisfies Meta<typeof MemoDetail>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+type Tag = {
+	id: number;
+	name: string;
+	priority: number;
+};
+
+type Comment = {
+	id: number;
+	memo_id: number;
+	content: string;
+	created_at: string;
+	updated_at: string;
+};
+
+type Memo = {
+	id: number;
+	title: string;
+	content: string;
+	poster: string;
+	created_at: string;
+	updated_at: string;
+	comments: Comment[];
+};
+
+const tags: Tag[] = [
+	{
+		id: 1,
+		name: 'タグ名1',
+		priority: 1,
+	},
+	{
+		id: 2,
+		name: 'タグ名2',
+		priority: 3,
+	},
+	{
+		id: 3,
+		name: 'タグ名3',
+		priority: 2,
+	},
+	{
+		id: 4,
+		name: 'タグ名1',
+		priority: 1,
+	},
+	{
+		id: 5,
+		name: 'タグ名2',
+		priority: 3,
+	},
+	{
+		id: 6,
+		name: 'タグ名3',
+		priority: 2,
+	},
+	{
+		id: 7,
+		name: 'タグ名1',
+		priority: 1,
+	},
+	{
+		id: 8,
+		name: 'タグ名2',
+		priority: 3,
+	},
+	{
+		id: 9,
+		name: 'タグ名111111111113',
+		priority: 2,
+	},
+	{
+		id: 10,
+		name: 'タグ名1',
+		priority: 1,
+	},
+	{
+		id: 11,
+		name: 'タグ名2',
+		priority: 3,
+	},
+	{
+		id: 12,
+		name: 'タグ名3',
+		priority: 2,
+	},
+	{
+		id: 13,
+		name: 'タグ名1',
+		priority: 1,
+	},
+	{
+		id: 14,
+		name: 'タグ名2',
+		priority: 3,
+	},
+	{
+		id: 15,
+		name: 'タグ名3',
+		priority: 2,
+	},
+	{
+		id: 16,
+		name: 'タグ名1',
+		priority: 1,
+	},
+];
+
+const memo: Memo = {
+	id: 1,
+	title: 'タイトルタイトルタイトルタイトルタイトル',
+	content:
+		'本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文本文',
+	poster: 'ユーザ名',
+	created_at: '2024-09-05T10:12:14.000Z',
+	updated_at: '2024-12-15T10:12:14.000Z',
+	comments: [],
+};
+
+export const Default: Story = {
+	args: {
+		memo: memo,
+		tags: tags,
+	},
+};

--- a/src/features/MemoDetail/index.tsx
+++ b/src/features/MemoDetail/index.tsx
@@ -2,6 +2,7 @@ import Text from '@/components/Text';
 import Title from '@/components/Title';
 import Tag from '@/components/Tag';
 import DateLabel from '@/components/DateLabel';
+import IconButton from '@/components/IconButton';
 
 type Tag = {
 	id: number;
@@ -36,9 +37,34 @@ export function MemoDetail({ memo, tags }: Props) {
 	const sortedTags = [...tags].sort((a, b) => {
 		return b.priority - a.priority;
 	});
+
+	const onClickEditButton = (id: number): any => {
+		console.log('edit id', { id });
+	};
+	const onClickDeleteButton = (id: number): any => {
+		console.log('delete id', { id });
+	};
 	return (
 		<div className='mt-10 flex flex-col justify-center gap-8 px-48'>
-			<Text>{memo.poster}</Text>
+			<div className='flex'>
+				<div className='mr-auto'>
+					<Text>{memo.poster}</Text>
+				</div>
+				<div className='flex'>
+					<IconButton
+						label='編集'
+						size='s'
+						iconType='edit'
+						onClickHandler={onClickEditButton(memo.id)}
+					></IconButton>
+					<IconButton
+						label='削除'
+						size='s'
+						iconType='delete'
+						onClickHandler={onClickDeleteButton(memo.id)}
+					></IconButton>
+				</div>
+			</div>
 			<Title
 				fontSize='l'
 				isBold

--- a/src/features/MemoDetail/index.tsx
+++ b/src/features/MemoDetail/index.tsx
@@ -1,0 +1,72 @@
+import Text from '@/components/Text';
+import Title from '@/components/Title';
+import Tag from '@/components/Tag';
+import DateLabel from '@/components/DateLabel';
+
+type Tag = {
+	id: number;
+	name: string;
+	priority: number;
+};
+
+type Comment = {
+	id: number;
+	memo_id: number;
+	content: string;
+	created_at: string;
+	updated_at: string;
+};
+
+type Memo = {
+	id: number;
+	title: string;
+	content: string;
+	poster: string;
+	created_at: string;
+	updated_at: string;
+	comments: Comment[];
+};
+
+type Props = {
+	memo: Memo;
+	tags: Tag[];
+};
+
+export function MemoDetail({ memo, tags }: Props) {
+	const sortedTags = [...tags].sort((a, b) => {
+		return b.priority - a.priority;
+	});
+	return (
+		<div className='mt-10 flex flex-col justify-center gap-8 px-48'>
+			<Text>{memo.poster}</Text>
+			<Title
+				fontSize='l'
+				isBold
+			>
+				{memo.title}
+			</Title>
+			<div className='flex flex-wrap'>
+				{sortedTags.map((tag) => {
+					return (
+						<div className='mb-1 mr-1'>
+							<Tag key={tag.id}>{tag.name}</Tag>
+						</div>
+					);
+				})}
+			</div>
+			<div className='flex space-x-2'>
+				<DateLabel
+					utcDateTimeString={memo.created_at}
+					label='登録日時'
+				/>
+				<DateLabel
+					utcDateTimeString={memo.updated_at}
+					label='更新日時'
+				/>
+			</div>
+			<div className='mt-3'>
+				<Text>{memo.content}</Text>
+			</div>
+		</div>
+	);
+}

--- a/src/hooks/useDateTime.ts
+++ b/src/hooks/useDateTime.ts
@@ -1,0 +1,28 @@
+/**
+ * 日付を変換するカスタムフック
+ * @param utcDateTimeString 想定文字列：「yyyy-MM-ddTHH:mm:ss.000Z」例）2024-09-15T10:12:14.000Z
+ * @param containSecond True：「yyyy/dd/m hh:mm:ss」返却, False：「yyyy/dd/m hh:mm」返却
+ * @returns 「yyyy/dd/m hh:mm:ss」か「yyyy/dd/m hh:mm」の形式の文字列（JST)
+ *           parseができない場合は「Nan」
+ */
+export const useDateTime = (
+	utcDateTimeString: string,
+	containSecond = true,
+): string | undefined => {
+	const utcDate = new Date(utcDateTimeString);
+
+	if (isNaN(utcDate.getTime())) {
+		return undefined;
+	}
+
+	const jstDate = new Date(utcDate.getTime() + 9 * 60 * 60 * 1000);
+	const year = jstDate.getFullYear();
+	const day = ('0' + jstDate.getDate()).slice(-2);
+	const month = ('0' + (jstDate.getMonth() + 1)).slice(-2);
+	const hours = ('0' + jstDate.getHours()).slice(-2);
+	const minutes = ('0' + jstDate.getMinutes()).slice(-2);
+	const seconds = ('0' + jstDate.getSeconds()).slice(-2);
+	const formattedDate = year + '/' + month + '/' + day + ' ' + hours + ':' + minutes;
+
+	return containSecond ? formattedDate + ':' + seconds : formattedDate;
+};


### PR DESCRIPTION
## 対応する issue

-   closes #39 
-   closes #17 

## 対応内容

- DateLabel の作成
    - 「yyyy/dd/m hh:mm:ss」形式で表示
    - 日付だけだとよくわからないのでラベルを追加
    -  parseができない文字列を渡された場合はレンダリングしないように変更
- useDateTime の作成（日付をparseするカスタムフック）
    - 「yyyy-MM-ddTHH:mm:ss.000Z」型の文字列を「yyyy/dd/m hh:mm:ss」もしくは「yyyy/dd/m hh:mm」にparse して返却
    - parseができない文字列を渡された場合は undefinded を返却
- memodetail の作成 

## 動作確認

- 日付ラベル
![image](https://github.com/user-attachments/assets/522bfa7c-4d21-4f2f-b11f-b687739165b5)
![image](https://github.com/user-attachments/assets/47ea62c3-d53d-4fb3-a392-0e3288802a05)

- メモ詳細
![image](https://github.com/user-attachments/assets/ec62e636-d791-4efd-bfd0-e721344fc229)
