### PR TITLE
Feature/#38 タグ作成・編集画面の実装(モック)

### DIFF
--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -4,10 +4,10 @@ import ColorButton from '@/components/ColorButton';
 
 type Props = {
 	onClose: () => void;
-	onClickSubmitButton: (...args: any[]) => any;
+	onClickSubmitButton: () => void;
 	tagName: string;
 	setTagName: (value: string) => void;
-	mode: 'edit' | 'create';
+	mode: 'edit' | 'create' | undefined;
 };
 
 const Modal = ({ onClose, onClickSubmitButton, tagName, setTagName, mode }: Props) => {

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -19,7 +19,11 @@ const Modal = ({ onClose, onClickSubmitButton, tagName, setTagName, mode }: Prop
 						fontSize='l'
 						isBold
 					>
-						{mode === 'edit' ? 'タグを編集' : 'タグを作成'}
+						{mode === 'edit'
+							? 'タグを編集'
+							: mode === 'create'
+								? 'タグを作成'
+								: ''}
 					</Title>
 					<button
 						className='i-ic-close px-3 py-3 text-gray-500 hover:opacity-75'

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -1,21 +1,18 @@
 import Input from '@/components/Input';
 import Title from '@/components/Title';
 import ColorButton from '@/components/ColorButton';
-import { useState } from 'react';
 
 type Props = {
 	onClose: () => void;
+	onClickSubmitButton: (...args: any[]) => any;
+	tagName: string;
+	setTagName: (value: string) => void;
 	mode: 'edit' | 'create';
 };
 
-const Modal = ({ onClose, mode }: Props) => {
-	const [name, setName] = useState('');
-	const onClickSubmitButton = () => {
-		console.log('submit');
-	};
-
+const Modal = ({ onClose, onClickSubmitButton, tagName, setTagName, mode }: Props) => {
 	return (
-		<div className='z-10 mx-auto max-w-4xl flex-col rounded-2xl border border-gray-400 py-10'>
+		<div className='mx-auto max-w-4xl flex-col rounded-2xl border border-gray-400 bg-white py-10'>
 			<div className='m-1 space-y-12 rounded-lg px-40 py-20 pl-10 pr-10 pt-20'>
 				<div className='flex justify-between'>
 					<Title
@@ -31,8 +28,8 @@ const Modal = ({ onClose, mode }: Props) => {
 				</div>
 				<Input
 					placeholder='タグ名'
-					setInputValue={setName}
-					inputValue={name}
+					setInputValue={setTagName}
+					inputValue={tagName}
 				/>
 				<div className='flex justify-end'>
 					<ColorButton

--- a/src/components/Modal/modal.stories.tsx
+++ b/src/components/Modal/modal.stories.tsx
@@ -12,6 +12,9 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
 	args: {
 		onClose: () => {},
+		onClickSubmitButton: () => {},
+		tagName: '',
+		setTagName: () => {},
 		mode: 'edit',
 	},
 };

--- a/src/components/TagTable/TagTable.stories.tsx
+++ b/src/components/TagTable/TagTable.stories.tsx
@@ -52,5 +52,7 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
 	args: {
 		tags: DUMMY_TAGS,
+		editOnClickIcon: (id: number) => {},
+		deleteOnClickIcon: (id: number) => {},
 	},
 };

--- a/src/components/TagTable/tagTable.tsx
+++ b/src/components/TagTable/tagTable.tsx
@@ -9,8 +9,8 @@ type Tag = {
 
 type Props = {
 	tags?: Tag[];
-	editOnClickIcon: (id: number) => unknown;
-	deleteOnClickIcon: (id: number) => unknown;
+	editOnClickIcon: (id: number) => void;
+	deleteOnClickIcon: (id: number) => void;
 };
 
 const TagTable = ({ tags, editOnClickIcon, deleteOnClickIcon }: Props) => {

--- a/src/components/TagTable/tagTable.tsx
+++ b/src/components/TagTable/tagTable.tsx
@@ -9,19 +9,14 @@ type Tag = {
 
 type Props = {
 	tags?: Tag[];
+	editOnClickIcon: (id: number) => unknown;
+	deleteOnClickIcon: (id: number) => unknown;
 };
 
-const TagTable = ({ tags }: Props) => {
-	const editOnClickIcon = (id: number): any => {
-		console.log(`edit: ${id}`);
-	};
-	const deleteOnClickIcon = (id: number): any => {
-		console.log(`delete: ${id}`);
-	};
-
+const TagTable = ({ tags, editOnClickIcon, deleteOnClickIcon }: Props) => {
 	return (
 		<div className='flex justify-center'>
-			<div className='w-4/5 space-y-2'>
+			<div className='space-y-2'>
 				{tags &&
 					tags?.length > 0 &&
 					tags.map((tag) => (

--- a/src/features/TagUpdate/TagUpdate.stories.tsx
+++ b/src/features/TagUpdate/TagUpdate.stories.tsx
@@ -1,0 +1,73 @@
+import TagUpdate from '.';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta = {
+	title: 'features/TagUpdate',
+	component: TagUpdate,
+} satisfies Meta<typeof TagUpdate>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+type Tag = {
+	id: number;
+	name: string;
+	priority: number;
+};
+
+const DUMMY_TAGS: Tag[] = [
+	{
+		id: 1,
+		name: 'タグ名1タグ名1タグ名1タグ名1タグ名1タグ名1タグ名1タグ名1タグ名1タグ名1タグ名1タグ名1タグ名1タグ名1タグ名1タグ名1タグ名1タグ名1',
+		priority: 100,
+	},
+	{
+		id: 2,
+		name: 'タグ名2',
+		priority: 3,
+	},
+	{
+		id: 3,
+		name: 'タグ名3',
+		priority: 2,
+	},
+	{
+		id: 4,
+		name: 'タグ名1',
+		priority: 1,
+	},
+	{
+		id: 5,
+		name: 'タグ名1',
+		priority: 1,
+	},
+	{
+		id: 6,
+		name: 'タグ名1',
+		priority: 1,
+	},
+	{
+		id: 7,
+		name: 'タグ名1',
+		priority: 1,
+	},
+	{
+		id: 8,
+		name: 'タグ名1',
+		priority: 1,
+	},
+	{
+		id: 9,
+		name: 'タグ名1',
+		priority: 1,
+	},
+];
+
+export const Default: Story = {
+	args: {
+		tags: DUMMY_TAGS,
+		onClickEditIcon: () => {},
+		onClickDeleteIcon: () => {},
+		onClickSubmitButton: () => {},
+	},
+};

--- a/src/features/TagUpdate/index.tsx
+++ b/src/features/TagUpdate/index.tsx
@@ -11,11 +11,17 @@ type Tag = {
 	priority: number;
 };
 
+type OptionalIdTag = {
+	id?: number;
+	name: string;
+	priority: number;
+};
+
 type Props = {
 	tags?: Tag[];
-	onClickEditIcon: (id: number) => any;
-	onClickDeleteIcon: (id: number) => any;
-	onClickSubmitButton: (tag: Tag) => any;
+	onClickEditIcon: (id: number) => void;
+	onClickDeleteIcon: (id: number) => void;
+	onClickSubmitButton: (tag: OptionalIdTag) => void;
 };
 
 const TagUpdate = ({
@@ -25,20 +31,29 @@ const TagUpdate = ({
 	onClickSubmitButton,
 }: Props) => {
 	const [tagName, setTagName] = useState('');
-	const [mode, setMode] = useState<'edit' | 'create' | 'list'>('list');
+	const [tagId, setTagId] = useState<number | undefined>(undefined);
+	const [mode, setMode] = useState<'edit' | 'create' | undefined>(undefined);
 	const createOnClickButton = () => {
+		setTagId(undefined);
 		setMode('create');
 	};
 	const editOnClickIcon = (id: number) => {
+		setTagId(id);
 		onClickEditIcon(id);
 		setMode('edit');
 	};
 	const deleteOnClickIcon = (id: number) => {
+		setTagId(id);
 		onClickDeleteIcon(id);
 	};
-	const submitOnClickButton = (tag: Tag) => {
+	const submitOnClickButton = () => {
+		const tag: OptionalIdTag = {
+			id: tagId,
+			name: tagName,
+			priority: 0,
+		};
 		onClickSubmitButton(tag);
-		setMode('list');
+		setMode(undefined);
 	};
 
 	return (
@@ -62,16 +77,16 @@ const TagUpdate = ({
 				</div>
 			</div>
 			<div
-				className={`${mode !== 'list' ? 'opacity-100' : 'pointer-events-none opacity-0'} fixed inset-10 z-10 items-center bg-white bg-opacity-50 opacity-100 transition-opacity duration-200`}
+				className={`${mode !== undefined ? 'pointer-events-auto opacity-100' : 'pointer-events-none opacity-0'} fixed inset-10 z-10 items-center bg-white bg-opacity-50 transition-opacity duration-200`}
 			>
 				<Modal
 					onClose={() => {
-						setMode('list');
+						setMode(undefined);
 					}}
 					onClickSubmitButton={submitOnClickButton}
 					tagName={tagName}
 					setTagName={setTagName}
-					mode={mode === 'list' ? 'create' : mode}
+					mode={mode}
 				></Modal>
 			</div>
 		</div>

--- a/src/features/TagUpdate/index.tsx
+++ b/src/features/TagUpdate/index.tsx
@@ -32,15 +32,15 @@ const TagUpdate = ({
 }: Props) => {
 	const [tagName, setTagName] = useState('');
 	const [tagId, setTagId] = useState<number | undefined>(undefined);
-	const [mode, setMode] = useState<'edit' | 'create' | undefined>(undefined);
+	const [mode, setMode] = useState<'edit' | 'create' | undefined>();
 	const createOnClickButton = () => {
-		setTagId(undefined);
 		setMode('create');
+		setTagId(undefined);
 	};
 	const editOnClickIcon = (id: number) => {
+		setMode('edit');
 		setTagId(id);
 		onClickEditIcon(id);
-		setMode('edit');
 	};
 	const deleteOnClickIcon = (id: number) => {
 		setTagId(id);

--- a/src/features/TagUpdate/index.tsx
+++ b/src/features/TagUpdate/index.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import ColorButton from '@/components/ColorButton';
+import TagTable from '@/components/TagTable/tagTable';
+import Modal from '@/components/Modal';
+import { useState } from 'react';
+
+type Tag = {
+	id: number;
+	name: string;
+	priority: number;
+};
+
+type Props = {
+	tags?: Tag[];
+	onClickEditIcon: (id: number) => any;
+	onClickDeleteIcon: (id: number) => any;
+	onClickSubmitButton: (tag: Tag) => any;
+};
+
+const TagUpdate = ({
+	tags,
+	onClickEditIcon,
+	onClickDeleteIcon,
+	onClickSubmitButton,
+}: Props) => {
+	const [tagName, setTagName] = useState('');
+	const [mode, setMode] = useState<'edit' | 'create' | 'list'>('list');
+	const createOnClickButton = () => {
+		setMode('create');
+	};
+	const editOnClickIcon = (id: number) => {
+		onClickEditIcon(id);
+		setMode('edit');
+	};
+	const deleteOnClickIcon = (id: number) => {
+		onClickDeleteIcon(id);
+	};
+	const submitOnClickButton = (tag: Tag) => {
+		onClickSubmitButton(tag);
+		setMode('list');
+	};
+
+	return (
+		<div>
+			<div className='mx-auto max-w-4xl flex-col py-10'>
+				<div className='m-1 space-y-12 px-40 py-20 pl-10 pr-10 pt-20'>
+					<div className='flex justify-end'>
+						<ColorButton
+							label='タグを作成'
+							color='blue'
+							handleClickButton={createOnClickButton}
+						></ColorButton>
+					</div>
+					<div className=''>
+						<TagTable
+							tags={tags}
+							editOnClickIcon={editOnClickIcon}
+							deleteOnClickIcon={deleteOnClickIcon}
+						></TagTable>
+					</div>
+				</div>
+			</div>
+			<div
+				className={`${mode !== 'list' ? 'opacity-100' : 'pointer-events-none opacity-0'} fixed inset-10 z-10 items-center bg-white bg-opacity-50 opacity-100 transition-opacity duration-200`}
+			>
+				<Modal
+					onClose={() => {
+						setMode('list');
+					}}
+					onClickSubmitButton={submitOnClickButton}
+					tagName={tagName}
+					setTagName={setTagName}
+					mode={mode === 'list' ? 'create' : mode}
+				></Modal>
+			</div>
+		</div>
+	);
+};
+
+export default TagUpdate;


### PR DESCRIPTION
## 対応する issue

-   closes #38 

## 対応内容

- タグ一覧画面の作成
    - 作成ボタン・編集ボタン押下時にモーダルを表示
    - モダール表示時は親画面のボタンは非活性
    - バツボタン・送信ボタン押下時にモーダルを閉じる
- モダールコンポーネントの修正
    - 背景を白に変更
    - モーダル自体の大きさを幅MAXにして親画面でサイズ調整
    - 送信ボタン押下時に発火する関数とinput要素のvalue, setValueを親画面で制御するように変更
- タグ作成・編集の修正
    - 編集関数と削除関数を親画面から受け渡すように修正
     
## 動作確認

https://github.com/user-attachments/assets/b51917b6-bfae-4621-8760-46052b1c03f9



