### PR TITLE
[fix]SSRかつuseStateを使用できるように、propsを受け渡すmemoListComponents側に移動(draft)

### DIFF
--- a/src/app/memoList/page.tsx
+++ b/src/app/memoList/page.tsx
@@ -1,20 +1,10 @@
-import { useState } from 'react';
-
-import { Tag } from '@/Types';
 import { getMemos } from '@/api/getMemos';
 import { getTags } from '@/api/getTags';
 import MemoList from '@/features/MemoList';
 
 export default async function MemoListPage() {
-	const [searchMemoContent, setSearchMemoContent] = useState('');
-	const [selectedChips, setSelectedChips] = useState<Tag[]>([]);
-
 	const memos = await getMemos();
 	const tags = await getTags();
-
-	const handleClickSearchButton = () => {
-		console.log('search');
-	};
 
 	if (!memos || memos.length === 0) {
 		return <div>メモが見つかりません</div>;
@@ -25,11 +15,6 @@ export default async function MemoListPage() {
 			memos={memos}
 			memoTotalPage={memos.length}
 			tags={tags}
-			searchMemoContent={searchMemoContent}
-			setSearchMemoContent={setSearchMemoContent}
-			selectedChips={selectedChips}
-			setSelectedChips={setSelectedChips}
-			handleClickSearchButton={handleClickSearchButton}
 		></MemoList>
 	);
 }

--- a/src/features/MemoList/MemoList.stories.tsx
+++ b/src/features/MemoList/MemoList.stories.tsx
@@ -109,10 +109,5 @@ export const Default: Story = {
 		memos: DUMMY_DATA_MEMOS,
 		memoTotalPage: 1,
 		tags: DUMMY_DATA_TAGS,
-		searchMemoContent: '',
-		setSearchMemoContent: () => {},
-		selectedChips: [],
-		setSelectedChips: () => {},
-		handleClickSearchButton: () => {},
 	},
 };

--- a/src/features/MemoList/index.tsx
+++ b/src/features/MemoList/index.tsx
@@ -1,3 +1,7 @@
+'use client';
+
+import { useState } from 'react';
+
 import { Memo, Tag } from '@/Types';
 import ColorButton from '@/components/ColorButton';
 import Input from '@/components/Input';
@@ -9,23 +13,16 @@ type Props = {
 	memos: Memo[];
 	memoTotalPage: number;
 	tags: Tag[];
-	searchMemoContent: string;
-	setSearchMemoContent: (searchValue: string) => void;
-	selectedChips: Tag[];
-	setSelectedChips: (selectedChips: Tag[]) => void;
-	handleClickSearchButton: () => void;
 };
 
-export function MemoList({
-	memos,
-	memoTotalPage,
-	tags,
-	searchMemoContent,
-	setSearchMemoContent,
-	selectedChips,
-	setSelectedChips,
-	handleClickSearchButton,
-}: Props) {
+const handleClickSearchButton = () => {
+	console.log('search');
+};
+
+export function MemoList({ memos, memoTotalPage, tags }: Props) {
+	const [searchMemoContent, setSearchMemoContent] = useState('');
+	const [selectedChips, setSelectedChips] = useState<Tag[]>([]);
+
 	return (
 		<div className='mt-10 flex flex-col justify-center gap-8 px-48'>
 			<div>

--- a/src/features/TagUpdate/index.tsx
+++ b/src/features/TagUpdate/index.tsx
@@ -21,12 +21,12 @@ const TagUpdate = ({
 	onClickSubmitButton,
 }: Props) => {
 	const [tagName, setTagName] = useState('');
-	const [tagId, setTagId] = useState<Tag['id']>(null);
+	const [tagId, setTagId] = useState<Tag['id']>(0);
 	const [mode, setMode] = useState<'edit' | 'create' | undefined>();
 
 	const createOnClickButton = () => {
 		setMode('create');
-		setTagId(null);
+		setTagId(0);
 	};
 	const editOnClickIcon = (id: number) => {
 		setMode('edit');


### PR DESCRIPTION
## 対応する issue

<!-- ここに対応するissue番号を書く。issue番号が99なら、「- closes #99」と書く。 -

## 対応内容

<!-- ここに対応した内容を書く。 -->
SSRのコンポーネントには関数をpropsで渡すこと、usestateを使用することができない
しかしCookieメソッドはSSR側の関数のため、正しくCookieを受け渡すには両方を共存できるようにする必要があるため下記を実施
- pageから呼び出すMemoList componentをクライアント componentに変更
- MemoListにuseStateや関数定義を移動
- pageではfetch関数の呼び出し、取得した値をpropsに渡すだけに変更

## 動作確認

<!-- ここにUIのスクショ等を貼る。 -->
![image](https://github.com/user-attachments/assets/bdbb4385-7216-4c06-bd59-a574a8aaf7a4)
